### PR TITLE
Scaffolding for RSS Feeds

### DIFF
--- a/app/src/common/api.service.js
+++ b/app/src/common/api.service.js
@@ -290,3 +290,9 @@ export const TwitterService = {
         return ApiService.query('twitter', {params});
     },
 };
+
+export const RssService = {
+    fetchFeed(params) {
+        return ApiService.query('rss', {params});
+    },
+};

--- a/app/src/store/actions.type.js
+++ b/app/src/store/actions.type.js
@@ -78,3 +78,5 @@ export const DELETE_COUNTRY_DETAILS = 'deleteCountryDetails';
 export const SEARCH_TWEETS = 'SEARCH_TWEETS';
 export const APPEND_TWEETS = 'APPEND_TWEETS';
 
+export const FETCH_RSS = 'FETCH_RSS';
+

--- a/app/src/store/event.module.js
+++ b/app/src/store/event.module.js
@@ -3,8 +3,8 @@
 
 import _ from 'lodash';
 import Vue from 'vue';
-import { EventsService, TwitterService } from '@/common/api.service';
-import { SEARCH_TWEETS, APPEND_TWEETS, FETCH_EVENT, CREATE_EVENT, EDIT_EVENT, DELETE_EVENT, ARCHIVE_EVENT, RESET_EVENT_STATE,
+import { EventsService, RssService, TwitterService } from '@/common/api.service';
+import { FETCH_RSS, SEARCH_TWEETS, APPEND_TWEETS, FETCH_EVENT, CREATE_EVENT, EDIT_EVENT, DELETE_EVENT, ARCHIVE_EVENT, RESET_EVENT_STATE,
     EDIT_EVENT_RESPONSES, EDIT_EVENT_EXT_CAPACITY, EDIT_EVENT_FIGURES, EDIT_EVENT_RESOURCES } from './actions.type';
 import { RESET_STATE, SET_EVENT, ADD_EVENT_EXT_CAPACITY, UPDATE_EVENT_EXT_CAPACITY, UPDATE_EVENT_FIGURES, UPDATE_EVENT_RESOURCES, UPDATE_KEY_FIGURES } from './mutations.type';
 
@@ -26,6 +26,7 @@ const initialState = {
     },
     keyFigures: [],
     tweets: [],
+    rssFeedItems: [],
 };
 
 const state = Object.assign({}, initialState);
@@ -36,6 +37,12 @@ const actions = {
             .then(({data}) => {
                 context.commit(APPEND_TWEETS, data);
                 return data;
+            });
+    },
+    [FETCH_RSS] (context, params){
+        return RssService.fetchFeed(params)
+            .then(({data}) => {
+                state.rssFeedItems = data.result;
             });
     },
     [FETCH_EVENT] (context, eventSlug, prevEvent){
@@ -347,6 +354,9 @@ const getters ={
     tweets(state){
         return state.tweets;
     },
+    rssFeedItems(state) {
+        return state.rssFeedItems;
+    }
 };
 
 export default {

--- a/app/src/views/NewsFeed/RssFeed.vue
+++ b/app/src/views/NewsFeed/RssFeed.vue
@@ -1,17 +1,50 @@
 <template>
-    <v-layout row justify-center>
-        rss
-    </v-layout>
+    <v-container class="rssFeed" grid-list-md>
+        <div class="rssHeader">
+            rss Header
+        </div>
+        <v-layout row wrap v-if="feedItems.length > 0">
+            <v-flex  xs12 md6 v-for="(item, i) in feedItems" :key="i">
+                <v-card class="rssFeedCard">
+                    {{item.properties.title}}
+                </v-card>
+            </v-flex>
+        </v-layout>
+    </v-container>
 </template>
 
 <script>
+/*eslint no-debugger: off*/
+/*eslint no-console: off*/
+/*eslint no-unused-vars: off*/
+
+import { mapGetters } from 'vuex';
+import { FETCH_RSS } from '@/store/actions.type';
 
 export default {
     name: 'event-rss',
     data () {
         return {
-            dialog: false
+            feedItems: [],
         };
+    },
+    mounted(){
+        this.fetchRss();
+    },
+    methods: {
+        fetchRss() {
+            this.$store.dispatch(FETCH_RSS, {});
+        },
+    },
+    computed: {
+        ...mapGetters([
+            'rssFeedItems',
+        ])
+    },
+    watch: {
+        rssFeedItems(newValue){ // eslint-disable-line no-unused-vars
+            this.feedItems = _.map(this.rssFeedItems, _.clone);
+        }
     }
 };
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -19,6 +19,7 @@ import layers from './routes/layers';
 import reports from './routes/reports';
 import twitter from './routes/twitter';
 import hazards from './routes/hazards';
+import rss from './routes/rss';
 import bookmarks from './routes/bookmarks';
 import utils from './routes/utils';
 import missions from './routes/missions';
@@ -44,6 +45,7 @@ export default ({ config, db, logger }) => {
     api.use('/reports', reports({ config, db, logger }));
     api.use('/twitter', twitter({ logger }));
     api.use('/hazards', hazards({ logger }));
+    api.use('/rss', rss({ logger }));
     api.use('/bookmarks', bookmarks({ config, db, logger }));
     api.use('/utils', utils({ config, db, logger }) );
     api.use('/missions', missions({ config, db, logger }));

--- a/src/api/routes/rss/index.js
+++ b/src/api/routes/rss/index.js
@@ -1,0 +1,49 @@
+import { Router } from 'express';
+
+import { ensureAuthenticated } from '../../../lib/util';
+
+// different rss feed parsers
+import { PDC } from '../../../lib/pdc-georss.js';
+import { GDACS } from '../../../lib/gdacs-georss.js';
+// import { USGS } from '../../../lib/usgs-georss.js';
+// import { TSR } from '../../../lib/tsr.js';
+// import { PTWC } from '../../../lib/ptwc-georss.js';
+// import { LRA } from '../../../lib/lracrisistracker.js';
+
+
+export default ({ logger }) => {
+    let api = Router();
+
+    // Get a list of all reports
+    api.get('/', ensureAuthenticated,
+        (req, res, next) => {
+
+            logger.warn('++ fetching rss');
+            // alerts
+            const rssPromises = [
+                PDC(),
+                GDACS(),
+            ];
+
+            Promise.all(rssPromises)
+                .then((promiseResults) => {
+
+                    // combine different results into one
+                    let events = [];
+                    for(var i = 0; i < promiseResults.length;i++){
+                        events = events.concat(promiseResults[i].features);
+                    }
+                    logger.warn('++ : ' + JSON.stringify({ 'results.length': events.length }));
+                    res.status(200).json({statusCode: 200, time:new Date().toISOString(), result:events});
+                })
+                .catch((err) => {
+                    /* istanbul ignore next */
+                    logger.error(err);
+                    /* istanbul ignore next */
+                    next(err);
+                });
+        }
+    );
+
+    return api;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,12 @@ import { init } from './server.js';
 // Import logging libraries
 import { createLogger, format, transports } from 'winston';
 
-const consoleLogger = new transports.Console();
+const consoleLogger = new transports.Console({
+    format: format.combine(
+        format.colorize(),
+        format.simple()
+    )
+});
 const logger = createLogger({
     level: config.LOG_LEVEL,
     format: format.json(),
@@ -46,6 +51,7 @@ logger.add(new transports.File({
 
 // If we are not in development and console logging has not been requested then remove it
 if (config.NODE_ENV !== 'development' && !config.LOG_CONSOLE) {
+    logger.debug(`Logger is being removed because of env ${config.NODE_ENV}`);
     logger.remove(consoleLogger);
 }
 


### PR DESCRIPTION
- created a new /rss backend endpoint which queries multiple rss endpoints (and uses the already extant parsers) and combines them together, along with a front-end action to query this endpoint 

after further discussion of exactly what rss will look like, we can further flesh out this endpoint and the filter parameters that it takes as arguments 